### PR TITLE
Updated the way that Identities and keys are retrieved

### DIFF
--- a/src/Simple.Data.Sqlite/SqliteConnectionProvider.cs
+++ b/src/Simple.Data.Sqlite/SqliteConnectionProvider.cs
@@ -8,6 +8,7 @@ using Simple.Data.Ado.Schema;
 namespace Simple.Data.Sqlite
 {
     [Export("db", typeof(IConnectionProvider))]
+    [Export("sqlite", typeof(IConnectionProvider))]
     public class SqliteConnectionProvider : IConnectionProvider
     {
         string _connectionString;

--- a/src/Simple.Data.SqliteTests/SchemaProviderTests.cs
+++ b/src/Simple.Data.SqliteTests/SchemaProviderTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using NUnit.Framework;
 using Simple.Data.Sqlite;
@@ -10,6 +12,20 @@ namespace Simple.Data.SqliteTests
     [TestFixture]
     public class SchemaProviderTest
     {
+        private static readonly string DatabasePath = Path.Combine(
+            Path.GetDirectoryName( Assembly.GetExecutingAssembly().CodeBase.Substring( 8 ) ),
+            "Northwind.db" );
+
+        SqliteSchemaProvider schemaProvider;
+
+        [SetUp]
+        public void Setup()
+        {
+            var connectionProvider = new SqliteConnectionProvider();
+            connectionProvider.SetConnectionString( string.Format( "Data Source={0}", DatabasePath ) );
+            schemaProvider = new SqliteSchemaProvider( connectionProvider );
+        }
+
         [Test]
         public void NullConnectionProviderCausesException()
         {
@@ -20,6 +36,39 @@ namespace Simple.Data.SqliteTests
         public void ProceduresIsEmpty()
         {
             Assert.AreEqual(0, new SqliteSchemaProvider(new SqliteConnectionProvider()).GetStoredProcedures().Count());
+        }
+
+        [Test]
+        public void TestPrimaryKeys()
+        {
+            var productTable = schemaProvider.GetTables().FirstOrDefault( t => t.ActualName == "Products" );
+            Assert.IsNotNull( productTable );
+
+            var pks = schemaProvider.GetPrimaryKey( productTable );
+            Assert.IsTrue( pks.Length == 1 );
+            Assert.AreEqual( pks[0], "ProductID" );
+        }
+
+        [Test]
+        public void TestIdentityColumn()
+        {
+            var productTable = schemaProvider.GetTables().FirstOrDefault( t => t.ActualName == "Products" );
+            Assert.IsNotNull( productTable );
+
+            var idColumn = schemaProvider.GetColumns( productTable ).FirstOrDefault( c => c.ActualName == "ProductID" );
+            Assert.IsNotNull( idColumn );
+            Assert.IsTrue( idColumn.IsIdentity );
+        }
+
+        [Test]
+        public void TestNotIdentityColumn()
+        {
+            var table = schemaProvider.GetTables().FirstOrDefault( t => t.ActualName == "InternationalOrders" );
+            Assert.IsNotNull( table );
+
+            var idColoumn = schemaProvider.GetColumns( table ).FirstOrDefault( c => c.ActualName == "OrderID" );
+            Assert.IsNotNull( idColoumn );
+            Assert.IsFalse( idColoumn.IsIdentity );
         }
     }
 }

--- a/src/Simple.Data.SqliteTests/SchemaProviderTests.cs
+++ b/src/Simple.Data.SqliteTests/SchemaProviderTests.cs
@@ -70,5 +70,16 @@ namespace Simple.Data.SqliteTests
             Assert.IsNotNull( idColoumn );
             Assert.IsFalse( idColoumn.IsIdentity );
         }
+
+        [Test]
+        public void TestForeignKeys()
+        {
+            var table = schemaProvider.GetTables().FirstOrDefault( t => t.ActualName == "Products" );
+            Assert.IsNotNull( table );
+
+            var foreignKeys = schemaProvider.GetForeignKeys( table );
+            Assert.IsNotNull( foreignKeys );
+            Assert.IsTrue( foreignKeys.Count() == 2 );
+        }
     }
 }


### PR DESCRIPTION
Hi, I noticed a problem where the schemaprovider was using if the column was a primary key to determine if it is an identity column.  This was not actually correct, given you can have I PK that is not and AUTOINCREMENT.  I have updated the schema provider to pull the information from the System.Data.Sqlite provider instead.
